### PR TITLE
feat: add reset_after=N auto-reset parameter to @track (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [0.11.0] — 2026-04-10
+
+### Added
+- `reset_after=N` parameter on `@track` decorator — automatically clears metrics for that specific function after every N invocations (successful and errored calls both count). Only the decorated function's data is reset; the rest of the registry is untouched. Thread-safe via per-decorator lock.
+- `reset_metric(name)` method on `MetricsRegistry` — resets samples and error count for a single named metric without affecting others.
+
+
 ## [0.3.0] — 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ report()
   api_calls: 42
 ================================================================================
 ```
+#### Auto-reset after N calls
+
+```python
+@track(reset_after=100)
+def process_order(order_id: int):
+    ...
+```
+
+When `process_order` has been called 100 times, its metrics (call count, latency, errors) are automatically cleared and the counter starts fresh. Only that function's data is reset — all other tracked functions are unaffected. Both successful and errored calls count toward N. Thread-safe.
 
 ---
 

--- a/pytrackio/_registry.py
+++ b/pytrackio/_registry.py
@@ -73,6 +73,10 @@ class MetricsRegistry:
         with self._lock:
             self._samples.clear(); self._errors.clear()
             self._counters.clear(); self._start=time.monotonic()
+    def reset_metric(self, name: str):
+        with self._lock:
+            self._samples.pop(name, None)
+            self._errors.pop(name, None)
     def uptime_seconds(self): return time.monotonic()-self._start
 
 _REGISTRY = MetricsRegistry()

--- a/pytrackio/core.py
+++ b/pytrackio/core.py
@@ -6,6 +6,7 @@ from ._registry import _REGISTRY
 from functools import wraps
 from typing import List, Optional, Dict, Any
 import json
+import threading
 
 DEFAULT_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]
 _HISTOGRAM__REGISTRY: Dict[str, Dict[float, int]] = {}
@@ -28,11 +29,12 @@ def _record_histogram(metric_name: str, duration_ms: float, buckets: List[float]
     
     _HISTOGRAM__REGISTRY[metric_name][float("inf")] += 1
 
-def track(func=None, *, name: str | None = None, histogram_buckets: List[float] | None = None): 
+def track(func=None, *, name: str | None = None, histogram_buckets: List[float] | None = None, reset_after: int | None = None):
     def decorator(fn):
         metric_name = name or getattr(fn, "__qualname__", fn.__name__)
         active_buckets = sorted(histogram_buckets) if histogram_buckets else DEFAULT_BUCKETS
-        
+        _call_count = 0
+        _call_lock = threading.Lock()
         if inspect.iscoroutinefunction(fn):
             @functools.wraps(fn)
             async def async_wrapper(*args, **kwargs):
@@ -44,9 +46,16 @@ def track(func=None, *, name: str | None = None, histogram_buckets: List[float] 
                     err = True 
                     raise e
                 finally:
+                    nonlocal _call_count
                     duration = (time.perf_counter() - start) * 1000
-                    _REGISTRY.record(metric_name, duration, err) 
+                    _REGISTRY.record(metric_name, duration, err)
                     _record_histogram(metric_name, duration, active_buckets)
+                    if reset_after is not None:
+                        with _call_lock:
+                            _call_count += 1
+                            if _call_count >= reset_after:
+                                _REGISTRY.reset_metric(metric_name)
+                                _call_count = 0
             return async_wrapper
 
         @functools.wraps(fn)
@@ -59,9 +68,16 @@ def track(func=None, *, name: str | None = None, histogram_buckets: List[float] 
                 err = True
                 raise e
             finally:
+                nonlocal _call_count
                 duration = (time.perf_counter() - start) * 1000
                 _REGISTRY.record(metric_name, duration, err)
                 _record_histogram(metric_name, duration, active_buckets)
+                if reset_after is not None:
+                    with _call_lock:
+                        _call_count += 1
+                        if _call_count >= reset_after:
+                            _REGISTRY.reset_metric(metric_name)
+                            _call_count = 0
         return sync_wrapper
 
     if func is None:

--- a/tests/test_reset_after.py
+++ b/tests/test_reset_after.py
@@ -1,0 +1,97 @@
+import pytest
+from pytrackio import track, get_registry
+
+
+def test_reset_after_resets_registry():
+    registry = get_registry()
+    registry.reset()
+
+    @track(reset_after=3)
+    def dummy():
+        pass
+
+    metric_name = dummy.__wrapped__.__qualname__ if hasattr(dummy, "__wrapped__") else "test_reset_after_resets_registry.<locals>.dummy"
+
+    dummy()
+    dummy()
+    assert registry.summary(metric_name) is not None  # not reset yet
+
+    dummy()  # 3rd call — triggers reset
+    assert registry.summary(metric_name) is None  # reset happened
+
+
+def test_reset_after_restarts_counter():
+    registry = get_registry()
+    registry.reset()
+
+    @track(reset_after=2)
+    def task():
+        pass
+
+    metric_name = "test_reset_after_restarts_counter.<locals>.task"
+
+    task()
+    task()  # reset
+    task()  # 1st call of new cycle
+    summary = registry.summary(metric_name)
+    assert summary is not None
+    assert summary.calls == 1  # only 1 call since last reset
+
+
+def test_reset_after_none_does_not_reset():
+    registry = get_registry()
+    registry.reset()
+
+    @track
+    def stable():
+        pass
+
+    metric_name = "test_reset_after_none_does_not_reset.<locals>.stable"
+
+    for _ in range(10):
+        stable()
+
+    summary = registry.summary(metric_name)
+    assert summary is not None
+    assert summary.calls == 10
+
+
+def test_reset_after_with_errors():
+    registry = get_registry()
+    registry.reset()
+
+    @track(reset_after=2)
+    def flaky():
+        raise ValueError("boom")
+
+    metric_name = "test_reset_after_with_errors.<locals>.flaky"
+
+    with pytest.raises(ValueError):
+        flaky()
+    with pytest.raises(ValueError):
+        flaky()  # 2nd call — triggers reset
+
+    assert registry.summary(metric_name) is None
+
+
+def test_reset_after_thread_safety():
+    import threading
+    registry = get_registry()
+    registry.reset()
+
+    @track(reset_after=50)
+    def concurrent():
+        pass
+
+    metric_name = "test_reset_after_thread_safety.<locals>.concurrent"
+
+    threads = [threading.Thread(target=concurrent) for _ in range(100)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Either reset happened twice (50+50) or once — both valid
+    summary = registry.summary(metric_name)
+    if summary:
+        assert summary.calls <= 50


### PR DESCRIPTION
Closes danshu3007-lang/pytrackio#3

## What this does
Adds `reset_after=N` parameter to the `@track` decorator. After N invocations, 
only that function's metrics are cleared. The rest of the registry is untouched.

## Behavior
- Both successful and errored calls count toward N
- Thread-safe via a per-decorator lock
- Works for both sync and async functions

## Edge case (known)
Under very heavy concurrency, a call recorded just before a reset triggers 
may get wiped in the same cycle. This is acceptable for a metrics library 
and won't cause crashes — just slightly early resets in extreme cases.

## Changes
- `pytrackio/core.py` — added `reset_after` param to `track()`
- `pytrackio/_registry.py` — added `reset_metric(name)` method
- `tests/test_reset_after.py` — 5 new tests
- `CHANGELOG.md` — v0.11.0 entry
- `README.md` — usage example