### PR TITLE
feat: add Django and Flask request tracking middleware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install package
-        run: pip install -e .
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install package with test dependencies
+        run: pip install -e ".[dev]"
       - name: Run tests
         run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -238,6 +238,63 @@ registry.reset()
 
 ---
 
+## Framework Middleware Integrations
+
+pytrackio can automatically track HTTP request performance in Django and Flask applications.
+
+### Django
+
+Add the middleware to your Django `settings.py`:
+
+```python
+MIDDLEWARE = [
+    "pytrackio.django_middleware.RequestPerformanceMiddleware",
+    # other middleware...
+]
+```
+
+Each request is recorded in pytrackio using the metric format:
+
+```text
+django.request.GET /dashboard
+django.request.POST /login
+```
+
+The middleware also adds an `X-Request-Duration-MS` response header.
+
+### Flask
+
+Register the Flask tracker when creating your app:
+
+```python
+from flask import Flask
+from pytrackio.flask_middleware import init_pytrackio
+
+app = Flask(__name__)
+init_pytrackio(app)
+```
+
+Each request is recorded in pytrackio using the metric format:
+
+```text
+flask.request.GET /dashboard
+flask.request.POST /login
+```
+
+The middleware also adds an `X-Request-Duration-MS` response header.
+
+You can print the collected request metrics with:
+
+```python
+from pytrackio import report
+
+report()
+```
+
+Django and Flask are optional integrations. They are not required for core pytrackio usage.
+
+---
+
 ## Real-world example
 ```python
 from pytrackio import track, timer, counter, report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ Homepage    = "https://github.com/danshu3007-lang/pytrackio"
 Repository  = "https://github.com/danshu3007-lang/pytrackio"
 "Bug Tracker" = "https://github.com/danshu3007-lang/pytrackio/issues"
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "django",
+    "flask",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["pytrackio*"]

--- a/pytrackio/django_middleware.py
+++ b/pytrackio/django_middleware.py
@@ -1,16 +1,52 @@
 import time
+
 from django.utils.deprecation import MiddlewareMixin
 
+from ._registry import _REGISTRY
+
+
 class RequestPerformanceMiddleware(MiddlewareMixin):
+    """
+    Django middleware for automatically tracking HTTP request performance.
+
+    Records each request in pytrackio's metrics registry using the metric name:
+    django.request.<METHOD> <PATH>
+
+    Example:
+        django.request.GET /dashboard
+        django.request.POST /login
+    """
+
     def process_request(self, request):
         """Store the start time when a request enters the middleware."""
-        request.start_time = time.perf_counter()
+        request.pytrackio_start_time = time.perf_counter()
 
     def process_response(self, request, response):
-        """Calculate duration and add it to the response headers."""
-        if hasattr(request, 'start_time'):
-            duration = time.perf_counter() - request.start_time
-            # Format to milliseconds for better readability
-            response['X-Request-Duration-MS'] = f"{duration * 1000:.2f}"
-        
+        """Record request duration and add it to the response headers."""
+        if hasattr(request, "pytrackio_start_time"):
+            duration_ms = (time.perf_counter() - request.pytrackio_start_time) * 1000
+            metric_name = f"django.request.{request.method} {request.path}"
+
+            _REGISTRY.record(
+                metric_name,
+                duration_ms,
+                error=response.status_code >= 500,
+            )
+
+            response["X-Request-Duration-MS"] = f"{duration_ms:.2f}"
+
         return response
+
+    def process_exception(self, request, exception):
+        """Record failed requests when a view raises an exception."""
+        if hasattr(request, "pytrackio_start_time"):
+            duration_ms = (time.perf_counter() - request.pytrackio_start_time) * 1000
+            metric_name = f"django.request.{request.method} {request.path}"
+
+            _REGISTRY.record(
+                metric_name,
+                duration_ms,
+                error=True,
+            )
+
+        return None

--- a/pytrackio/flask_middleware.py
+++ b/pytrackio/flask_middleware.py
@@ -1,7 +1,22 @@
 import time
-from flask import request, g
+
+from flask import g, request
+
+from ._registry import _REGISTRY
+
 
 class FlaskPerformanceTracker:
+    """
+    Flask extension for automatically tracking HTTP request performance.
+
+    Records each request in pytrackio's metrics registry using the metric name:
+    flask.request.<METHOD> <PATH>
+
+    Example:
+        flask.request.GET /dashboard
+        flask.request.POST /login
+    """
+
     def __init__(self, app=None):
         if app is not None:
             self.init_app(app)
@@ -9,12 +24,56 @@ class FlaskPerformanceTracker:
     def init_app(self, app):
         app.before_request(self.before_request)
         app.after_request(self.after_request)
+        app.teardown_request(self.teardown_request)
+        return app
 
     def before_request(self):
-        g.start_time = time.perf_counter()
+        """Store the start time before Flask handles the request."""
+        g.pytrackio_start_time = time.perf_counter()
 
     def after_request(self, response):
-        if hasattr(g, 'start_time'):
-            duration = time.perf_counter() - g.start_time
-            response.headers['X-Request-Duration-MS'] = f"{duration * 1000:.2f}"
+        """Record successful request duration and add it to response headers."""
+        if hasattr(g, "pytrackio_start_time"):
+            duration_ms = (time.perf_counter() - g.pytrackio_start_time) * 1000
+            metric_name = f"flask.request.{request.method} {request.path}"
+
+            _REGISTRY.record(
+                metric_name,
+                duration_ms,
+                error=response.status_code >= 500,
+            )
+
+            response.headers["X-Request-Duration-MS"] = f"{duration_ms:.2f}"
+            g.pytrackio_recorded = True
+
         return response
+
+    def teardown_request(self, exception=None):
+        """Record failed requests when Flask exits with an exception."""
+        if exception is None:
+            return
+
+        if hasattr(g, "pytrackio_start_time") and not getattr(g, "pytrackio_recorded", False):
+            duration_ms = (time.perf_counter() - g.pytrackio_start_time) * 1000
+            metric_name = f"flask.request.{request.method} {request.path}"
+
+            _REGISTRY.record(
+                metric_name,
+                duration_ms,
+                error=True,
+            )
+
+
+def init_pytrackio(app):
+    """
+    Register pytrackio request performance tracking on a Flask app.
+
+    Example:
+        from flask import Flask
+        from pytrackio.flask_middleware import init_pytrackio
+
+        app = Flask(__name__)
+        init_pytrackio(app)
+    """
+    tracker = FlaskPerformanceTracker(app)
+    return tracker

--- a/tests/test_django_middleware.py
+++ b/tests/test_django_middleware.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEFAULT_CHARSET="utf-8",
+        SECRET_KEY="test-secret-key",
+        ALLOWED_HOSTS=["*"],
+    )
+
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from pytrackio import get_registry
+from pytrackio.django_middleware import RequestPerformanceMiddleware
+
+
+def test_django_middleware_tracks_successful_request():
+    registry = get_registry()
+    registry.reset()
+
+    request = RequestFactory().get("/hello")
+
+    def get_response(request):
+        return HttpResponse("ok", status=200)
+
+    middleware = RequestPerformanceMiddleware(get_response)
+    response = middleware(request)
+
+    summary = registry.summary("django.request.GET /hello")
+
+    assert response.status_code == 200
+    assert "X-Request-Duration-MS" in response
+    assert summary is not None
+    assert summary.calls == 1
+    assert summary.errors == 0
+
+
+def test_django_middleware_tracks_server_error_response():
+    registry = get_registry()
+    registry.reset()
+
+    request = RequestFactory().get("/error")
+
+    def get_response(request):
+        return HttpResponse("error", status=500)
+
+    middleware = RequestPerformanceMiddleware(get_response)
+    response = middleware(request)
+
+    summary = registry.summary("django.request.GET /error")
+
+    assert response.status_code == 500
+    assert summary is not None
+    assert summary.calls == 1
+    assert summary.errors == 1

--- a/tests/test_flask_middleware.py
+++ b/tests/test_flask_middleware.py
@@ -1,0 +1,45 @@
+from flask import Flask
+
+from pytrackio import get_registry
+from pytrackio.flask_middleware import FlaskPerformanceTracker, init_pytrackio
+
+
+def test_flask_middleware_tracks_successful_request():
+    registry = get_registry()
+    registry.reset()
+
+    app = Flask(__name__)
+    FlaskPerformanceTracker(app)
+
+    @app.get("/hello")
+    def hello():
+        return "ok"
+
+    response = app.test_client().get("/hello")
+    summary = registry.summary("flask.request.GET /hello")
+
+    assert response.status_code == 200
+    assert "X-Request-Duration-MS" in response.headers
+    assert summary is not None
+    assert summary.calls == 1
+    assert summary.errors == 0
+
+
+def test_flask_middleware_tracks_server_error_response():
+    registry = get_registry()
+    registry.reset()
+
+    app = Flask(__name__)
+    init_pytrackio(app)
+
+    @app.get("/error")
+    def error():
+        return "error", 500
+
+    response = app.test_client().get("/error")
+    summary = registry.summary("flask.request.GET /error")
+
+    assert response.status_code == 500
+    assert summary is not None
+    assert summary.calls == 1
+    assert summary.errors == 1


### PR DESCRIPTION
## What changed

- Updated Django middleware to record request duration in pytrackio's metrics registry
- Updated Flask middleware to record request duration using request lifecycle hooks
- Added response duration headers for tracked requests
- Added tests for Django and Flask middleware behavior
- Added README examples for enabling both integrations

## Notes

- Django and Flask remain optional integrations and are not added as required runtime dependencies.
- Request metrics use the naming format:
  - `django.request.<METHOD> <PATH>`
  - `flask.request.<METHOD> <PATH>`

## Testing

- Ran `pytest`
- Result: `44 passed`